### PR TITLE
Reflect Tendermint subversion in `glide --version`

### DIFF
--- a/glide.go
+++ b/glide.go
@@ -34,7 +34,7 @@ import (
 	"os"
 )
 
-var version = "0.13.2-dev"
+var version = "0.13.2-tendermint"
 
 const usage = `Vendor Package Management for your Go projects.
 


### PR DESCRIPTION
This will help with debugging issues with glide by distinguishing between Tendermint's version of and the upstream/default.